### PR TITLE
Add support for Chamber Temperature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.swp
 *.pyc
 
+
+.vscode/

--- a/octoprint_setandwait/__init__.py
+++ b/octoprint_setandwait/__init__.py
@@ -6,12 +6,32 @@ __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2020 Shawn Bruce - Released under terms of the AGPLv3 License"
 
 import octoprint.plugin
-from octoprint.events import Events
+from octoprint.events import Events, eventManager
 import threading
 import re
 import time
 
+
 class SetAndWait(octoprint.plugin.EventHandlerPlugin):
+    temp_setting = {
+        'tool': {
+            'residency_time': 10,
+            'window': 1,
+            'hysteresis': 3,
+        },
+        'bed': {
+            'residency_time': 5 * 60,
+            'window': 1,
+            'hysteresis': 3,
+        },
+        'chamber': {
+            'residency_time': 10 * 60,
+            'window': 3,
+            'hysteresis': 5,
+        }
+    }
+
+    waiting = False
 
     def __init__(self):
         self._events = dict(M109=threading.Event(),
@@ -19,17 +39,62 @@ class SetAndWait(octoprint.plugin.EventHandlerPlugin):
                             M191=threading.Event()
                             )
 
+    def _get_actual_temp_for_heater(self, heater_type, tool):
+        heaters = self._printer.get_current_temperatures()
+
+        if heater_type == 'tool':
+            temp = heaters['tool' + str(tool)]['actual']
+        elif heater_type == 'bed':
+            temp = heaters['bed']['actual']
+
+        return temp
+
+    def _wait_temp_reach_target(self, gcode_from, heater_type, mode, tool, target):
+        self._events[gcode_from].set()
+
+        while self._events[gcode_from].is_set() and self.waiting:
+            actual = self._get_actual_temp_for_heater(heater_type, tool)
+
+            self._logger.debug("Heater: {}, Mode, {}, Target: {}, Actual {}".format(
+                heater_type, mode, target, actual))
+
+            if mode == 'S':
+                if target - actual <= self.temp_setting[heater_type]['window']:
+                    break
+            elif mode == 'R':
+                if abs(target - actual) <= self.temp_setting[heater_type]['window']:
+                    break
+
+            self._poll_temperature_bypass_queue()
+            time.sleep(1)
+
+    def _wait_temp_stable(self, gcode_from, heater_type, mode, tool, target):
+        wait_finished = False
+        while not wait_finished and self.waiting:
+            self._wait_temp_reach_target(gcode_from, heater_type, mode, tool, target)
+            wait_finished = True
+
+            start_time = time.time()
+            while time.time() - start_time < self.temp_setting[heater_type]['residency_time'] and self.waiting:
+                actual = self._get_actual_temp_for_heater(heater_type, tool)
+                if abs(target - actual) > self.temp_setting[heater_type]['hysteresis']:
+                    wait_finished = False
+                    break
+
+                self._poll_temperature_bypass_queue()
+                time.sleep(1)
+
     def _poll_temperature_bypass_queue(self):
         # Adapted from octoprint.util.comm._poll_temperature
 
         if self._printer._comm.isOperational() \
-            and not self._printer._comm._temperature_autoreporting \
-            and not self._printer._comm._connection_closing \
-            and not self._printer._comm.isStreaming() \
-            and not self._printer._comm._long_running_command \
-            and not self._printer._comm._heating \
-            and not self._printer._comm._dwelling_until \
-            and not self._printer._comm._manualStreaming:
+                and not self._printer._comm._temperature_autoreporting \
+                and not self._printer._comm._connection_closing \
+                and not self._printer._comm.isStreaming() \
+                and not self._printer._comm._long_running_command \
+                and not self._printer._comm._heating \
+                and not self._printer._comm._dwelling_until \
+                and not self._printer._comm._manualStreaming:
             self._printer._comm._do_send('M105', gcode='M105')
 
     def _gcode_setandwait(self, line):
@@ -78,43 +143,31 @@ class SetAndWait(octoprint.plugin.EventHandlerPlugin):
             cmd += ' T{}'.format(tool)
         self._printer._comm._do_send(cmd, gcode=gcode_to)
 
-        self._events[gcode_from].set()
-        while self._events[gcode_from].is_set():
-            heaters = self._printer.get_current_temperatures()
-            if heater_type == 'tool':
-                actual = heaters['tool' + str(tool)]['actual']
-            elif heater_type == 'bed':
-                actual = heaters['bed']['actual']
-
-            self._logger.debug("Heater: {}, Mode, {}, Target: {}, Actual {}".format(heater_identifier, mode, target, actual))
-
-            if mode == 'S':
-                if actual >= target:
-                    break
-            elif mode == 'R':
-                self._logger.warning("Accurate temperature not yet implemented. line={}".format(line))
-                break
-
-            self._poll_temperature_bypass_queue()
-            time.sleep(1)
+        self._wait_temp_stable(gcode_from, heater_type, mode, tool, target)
 
         if not self._events[gcode_from].is_set():
-            self._logger.debug("{} aborted".format(gcode_from, heater_identifier))
+            self._logger.debug("{} aborted".format(
+                gcode_from, heater_identifier))
 #            cmd = '{} S0'.format(gcode_to)
 #            if tool:
 #                cmd += ' T{}'.format(tool)
 #            self._printer._comm._do_send(cmd, gcode=gcode_to)
             return
 
-        self._logger.debug("{} - Giving the controller the final say!".format(gcode_from))
-        self._printer._comm._do_send(line)
+        # self._logger.debug(
+        #     "{} - Giving the controller the final say!".format(gcode_from))
+        # self._printer._comm._do_send(line)
 
     def hook_gcode_sending(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
+        if gcode == 'M108':
+            self.waiting = False
+            return
         if gcode not in ['M104', 'M109', 'M140', 'M141', 'M190', 'M191']:
             return
 
         if gcode in ['M109', 'M190', 'M191']:
             if not self._printer.is_cancelling():
+                self.waiting = True
                 self._printer.set_job_on_hold(True, blocking=False)
                 self._gcode_setandwait(cmd)
                 self._printer.set_job_on_hold(False)
@@ -125,6 +178,7 @@ class SetAndWait(octoprint.plugin.EventHandlerPlugin):
         if event in [Events.DISCONNECTING,
                      Events.PRINT_CANCELLING,
                      Events.ERROR]:
+            self.waiting = False
             for k, e in self._events.items():
                 if e.is_set():
                     self._logger.debug("Aborting {}".format(k))
@@ -147,8 +201,10 @@ class SetAndWait(octoprint.plugin.EventHandlerPlugin):
             )
         )
 
+
 __plugin_name__ = "SetAndWait"
 __plugin_pythoncompat__ = ">=2.7,<4"
+
 
 def __plugin_load__():
     global __plugin_implementation__

--- a/octoprint_setandwait/__init__.py
+++ b/octoprint_setandwait/__init__.py
@@ -15,7 +15,9 @@ class SetAndWait(octoprint.plugin.EventHandlerPlugin):
 
     def __init__(self):
         self._events = dict(M109=threading.Event(),
-                            M190=threading.Event())
+                            M190=threading.Event(),
+                            M191=threading.Event()
+                            )
 
     def _poll_temperature_bypass_queue(self):
         # Adapted from octoprint.util.comm._poll_temperature
@@ -45,6 +47,10 @@ class SetAndWait(octoprint.plugin.EventHandlerPlugin):
             gcode_to = 'M140'
             heater_type = 'bed'
             heater_identifier = 'Bed'
+        elif gcode_from == 'M191':
+            gcode_to = 'M141'
+            heater_type = 'chamber'
+            heater_identifier = 'Chamber'
         else:
             return
 
@@ -104,10 +110,10 @@ class SetAndWait(octoprint.plugin.EventHandlerPlugin):
         self._printer._comm._do_send(line)
 
     def hook_gcode_sending(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
-        if gcode not in ['M104', 'M109', 'M140', 'M190']:
+        if gcode not in ['M104', 'M109', 'M140', 'M141', 'M190', 'M191']:
             return
 
-        if gcode in ['M109', 'M190']:
+        if gcode in ['M109', 'M190', 'M191']:
             if not self._printer.is_cancelling():
                 self._printer.set_job_on_hold(True, blocking=False)
                 self._gcode_setandwait(cmd)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 plugin_identifier = "setandwait"
 plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-SetAndWait"
-plugin_version = "0.0.1"
+plugin_version = "0.0.2"
 plugin_description = "Re-implements Set And Wait commands"
 plugin_author = "Shawn Bruce"
 plugin_author_email = "kantlivelong@gmail.com"


### PR DESCRIPTION
Thank you for your interest into contributing to OctoPrint-SetAndWait, it's highly appreciated!

Before submitting please make sure you have ticked all points on this checklist:

  * [x] Your PR targets the devel branch.
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master or devel please)
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style.
  * [x] You have tested your changes (please state how!)

Feel free to delete all this help text, then describe your PR further. You may use the template provided below to do that. The more details the better!

---

#### What does this PR do and why is it necessary?
I planned to make a heated chamber for my printer. Also I want to wait for my bed temperature to stable for about 5 mins so I also add waiting, similar to Marlin. And I also added a support for M108 (untested)

#### How was it tested? How can it be tested by the reviewer?
I have tried running gcode files with command listed below
`First file`
```gcode
M109 S100
G28
```
`Second file`
```gcode
M190 S50
G28
```
All work fine.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
The time waited and temperature window is still hardcoded, I would suggest creating UI for it (I don't develop Octoprint Plugin so I don't know how.).
